### PR TITLE
Jump action fix

### DIFF
--- a/SnailKnight/Scenes/Level1.cpp
+++ b/SnailKnight/Scenes/Level1.cpp
@@ -54,7 +54,7 @@ void Level1::HandleEvent(SDL_Event * Event) {
 		if (Event->key.keysym.sym == SDLK_LEFT)	this->Player->MoveLeft = true;
 		if (Event->key.keysym.sym == SDLK_RIGHT) this->Player->MoveRight = true;
 		if (Event->key.keysym.sym == SDLK_DOWN) this->Player->InShell = true;
-		if (Event->key.keysym.sym == SDLK_SPACE && Event->key.repeat > 0) this->Player->Jump = true;
+		if (Event->key.keysym.sym == SDLK_SPACE && Event->key.repeat == 0) this->Player->Jump = true;
 		if (Event->key.keysym.sym == SDLK_LSHIFT) this->Player->Cling = true;
 		break;
 


### PR DESCRIPTION
- Event->key.repeat logic for Jump event in Level1.cpp changed from repeat > 0 to repeat == 0. Literally the only change I didn't test. Whoops.